### PR TITLE
Add thrift 0.21.0

### DIFF
--- a/Formula/thrift@0.21.rb
+++ b/Formula/thrift@0.21.rb
@@ -1,0 +1,87 @@
+class ThriftAT021 < Formula
+  desc "Framework for scalable cross-language services development"
+  homepage "https://thrift.apache.org/"
+  license "Apache-2.0"
+
+  stable do
+    url "https://www.apache.org/dyn/closer.lua?path=thrift/0.21.0/thrift-0.21.0.tar.gz"
+    mirror "https://archive.apache.org/dist/thrift/0.21.0/thrift-0.21.0.tar.gz"
+    sha256 "9a24f3eba9a4ca493602226c16d8c228037db3b9291c6fc4019bfe3bd39fc67c"
+  end
+
+  bottle do
+    rebuild 1
+  end
+
+  head do
+    url "https://github.com/apache/thrift.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "pkg-config" => :build
+  end
+
+  depends_on "bison" => :build
+  depends_on "boost" => [:build, :test]
+  depends_on "openssl@3"
+  uses_from_macos "zlib"
+
+  def install
+    system "./bootstrap.sh" unless build.stable?
+
+    args = %W[
+      --disable-debug
+      --disable-tests
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
+      --without-java
+      --without-kotlin
+      --without-python
+      --without-py3
+      --without-ruby
+      --without-haxe
+      --without-netstd
+      --without-perl
+      --without-php
+      --without-php_extension
+      --without-dart
+      --without-erlang
+      --without-go
+      --without-d
+      --without-nodejs
+      --without-nodets
+      --without-lua
+      --without-rs
+      --without-swift
+    ]
+
+    ENV.cxx11 if ENV.compiler == :clang
+
+    # Don't install extensions to /usr:
+    ENV["PY_PREFIX"] = prefix
+    ENV["PHP_PREFIX"] = prefix
+    ENV["JAVA_PREFIX"] = buildpath
+
+    system "./configure", *args
+    ENV.deparallelize
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.thrift").write <<~EOS
+      service MultiplicationService {
+        i32 multiply(1:i32 x, 2:i32 y),
+      }
+    EOS
+
+    system "#{bin}/thrift", "-r", "--gen", "cpp", "test.thrift"
+
+    system ENV.cxx, "-std=c++11", "gen-cpp/MultiplicationService.cpp",
+      "gen-cpp/MultiplicationService_server.skeleton.cpp",
+      "-I#{include}/include",
+      "-L#{lib}", "-lthrift"
+  end
+end


### PR DESCRIPTION
Tested on my Mac:
```
% brew install rkurniawati/thrift/thrift@0.21
==> Tapping rkurniawati/thrift
Cloning into '/opt/homebrew/Library/Taps/rkurniawati/homebrew-thrift'...
remote: Enumerating objects: 121, done.
remote: Counting objects: 100% (121/121), done.
remote: Compressing objects: 100% (93/93), done.
remote: Total 121 (delta 63), reused 76 (delta 27), pack-reused 0 (from 0)
Receiving objects: 100% (121/121), 22.49 KiB | 7.50 MiB/s, done.
Resolving deltas: 100% (63/63), done.
Tapped 13 formulae (26 files, 59.4KB).
==> Fetching dependencies for rkurniawati/thrift/thrift@0.21: bison and boost
==> Fetching bison
==> Downloading https://ghcr.io/v2/homebrew/core/bison/manifests/3.8.2
Already downloaded: /Users/rkurniawati/Library/Caches/Homebrew/downloads/0a84b14c20dfba4609542ea4b14a4eb93d369f7f83f373b568017fc7d76b6505--bison-3.8.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/bison/blobs/sha256:d45a8c193646a25d281a6d3fd62d6f756d4e392cc2948e605a62f3d88ccbf188
Already downloaded: /Users/rkurniawati/Library/Caches/Homebrew/downloads/c3a79f097ffda8413a62c4d422326bc892132edbc918b416fdf5ff9923d129c0--bison--3.8.2.arm64_sequoia.bottle.tar.gz
==> Fetching boost
==> Downloading https://ghcr.io/v2/homebrew/core/boost/manifests/1.88.0
Already downloaded: /Users/rkurniawati/Library/Caches/Homebrew/downloads/d1d650e10b72bb083df7414ad7171a3c5cf1d0d72a3e3773ec969dffbea19d9a--boost-1.88.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/boost/blobs/sha256:40110dc77bd85db9b7bfc5c23d1cbd58f8ef501ba355484419f9d11ccabaefc1
Already downloaded: /Users/rkurniawati/Library/Caches/Homebrew/downloads/0a53d3c4b5fdb32bdaa3936966cf165c1018c20dfdc13b7c6e869075b36033d7--boost--1.88.0.arm64_sequoia.bottle.tar.gz
==> Fetching rkurniawati/thrift/thrift@0.21
==> Downloading https://www.apache.org/dyn/closer.lua?path=thrift/0.21.0/thrift-0.21.0.tar.gz
Already downloaded: /Users/rkurniawati/Library/Caches/Homebrew/downloads/68776804110523ba743d4c516db587c40f5a5bd7fb5a855cc58b20027980e174--thrift-0.21.0.tar.gz
==> Installing thrift@0.21 from rkurniawati/thrift
==> Installing dependencies for rkurniawati/thrift/thrift@0.21: bison and boost
==> Installing rkurniawati/thrift/thrift@0.21 dependency: bison
==> Downloading https://ghcr.io/v2/homebrew/core/bison/manifests/3.8.2
Already downloaded: /Users/rkurniawati/Library/Caches/Homebrew/downloads/0a84b14c20dfba4609542ea4b14a4eb93d369f7f83f373b568017fc7d76b6505--bison-3.8.2.bottle_manifest.json
==> Pouring bison--3.8.2.arm64_sequoia.bottle.tar.gz
🍺  /opt/homebrew/Cellar/bison/3.8.2: 100 files, 3.7MB
==> Installing rkurniawati/thrift/thrift@0.21 dependency: boost
==> Downloading https://ghcr.io/v2/homebrew/core/boost/manifests/1.88.0
Already downloaded: /Users/rkurniawati/Library/Caches/Homebrew/downloads/d1d650e10b72bb083df7414ad7171a3c5cf1d0d72a3e3773ec969dffbea19d9a--boost-1.88.0.bottle_manifest.json
==> Pouring boost--1.88.0.arm64_sequoia.bottle.tar.gz
🍺  /opt/homebrew/Cellar/boost/1.88.0: 16,266 files, 346.2MB
==> Installing rkurniawati/thrift/thrift@0.21
==> ./configure --disable-tests --with-openssl=/opt/homebrew/opt/openssl@3 --without-java --without-kotlin --without-python --without-py3 --without-ruby --without-haxe --without-netstd --without-perl --without-php --without-php_extension --without-dart --without-erlang
==> make
==> make install
🍺  /opt/homebrew/Cellar/thrift@0.21/0.21.0: 106 files, 6.8MB, built in 2 minutes 19 seconds
==> Running `brew cleanup thrift@0.21`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```