### PR TITLE
Add thrift 0.22 formula

### DIFF
--- a/Formula/thrift@0.22.rb
+++ b/Formula/thrift@0.22.rb
@@ -1,0 +1,89 @@
+class ThriftAT022 < Formula
+  desc "Framework for scalable cross-language services development"
+  homepage "https://thrift.apache.org/"
+  license "Apache-2.0"
+
+  stable do
+    url "https://www.apache.org/dyn/closer.lua?path=thrift/0.22.0/thrift-0.22.0.tar.gz"
+    mirror "https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz"
+    sha256 "794a0e455787960d9f27ab92c38e34da27e8deeda7a5db0e59dc64a00df8a1e5"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
+
+  head do
+    url "https://github.com/apache/thrift.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "pkgconf" => :build
+  end
+
+  depends_on "bison" => :build
+  depends_on "boost" => [:build, :test]
+  depends_on "openssl@3"
+  uses_from_macos "zlib"
+
+  def install
+    system "./bootstrap.sh" unless build.stable?
+
+    args = %W[
+      --disable-debug
+      --disable-tests
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
+      --without-java
+      --without-kotlin
+      --without-python
+      --without-py3
+      --without-ruby
+      --without-haxe
+      --without-netstd
+      --without-perl
+      --without-php
+      --without-php_extension
+      --without-dart
+      --without-erlang
+      --without-go
+      --without-d
+      --without-nodejs
+      --without-nodets
+      --without-lua
+      --without-rs
+      --without-swift
+    ]
+
+    ENV.cxx11 if ENV.compiler == :clang
+
+    # Don't install extensions to /usr:
+    ENV["PY_PREFIX"] = prefix
+    ENV["PHP_PREFIX"] = prefix
+    ENV["JAVA_PREFIX"] = buildpath
+
+    system "./configure", *args
+    ENV.deparallelize
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.thrift").write <<~THRIFT
+      service MultiplicationService {
+        i32 multiply(1:i32 x, 2:i32 y),
+      }
+    THRIFT
+
+    system bin/"thrift", "-r", "--gen", "cpp", "test.thrift"
+
+    system ENV.cxx, "-std=c++11", "gen-cpp/MultiplicationService.cpp",
+      "gen-cpp/MultiplicationService_server.skeleton.cpp",
+      "-I#{include}/include",
+      "-L#{lib}", "-lthrift"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ brew install thrift@0.11
 - `thrift@0.19`
 - `thrift@0.20`
 - `thrift@0.21`
+- `thrift@0.22`
 
 ## Maintenance Notes
 
-- Latest version in this tap: `thrift@0.21`.
-- Supported historical releases currently cover `thrift@0.9` through `thrift@0.21`.
+- Latest version in this tap: `thrift@0.22`.
+- Supported historical releases currently cover `thrift@0.9` through `thrift@0.22`.
 - Recent maintenance work focused on adding missing archived versions, fixing patch URLs, and switching old source downloads to `archive.apache.org`.
 - Older formulae are largely copied from `homebrew-core` history and adjusted for source builds without bottles.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,11 +36,12 @@ brew install thrift@0.11
 - `thrift@0.19`
 - `thrift@0.20`
 - `thrift@0.21`
+- `thrift@0.22`
 
 ## 维护说明
 
-- 当前最新版本为 `thrift@0.21`。
-- 目前维护的历史版本范围为 `thrift@0.9` 到 `thrift@0.21`。
+- 当前最新版本为 `thrift@0.22`。
+- 目前维护的历史版本范围为 `thrift@0.9` 到 `thrift@0.22`。
 - 最近的维护重点主要是补齐历史版本、修复 patch URL，以及将旧版本源码地址切换到 `archive.apache.org`。
 - 大部分旧 formula 来自 `homebrew-core` 历史版本，并已调整为仅支持源码安装、不提供 bottle。
 


### PR DESCRIPTION
## Summary / 概要

- Add `thrift@0.22` formula extracted from `homebrew/core` history.
- Align the new formula with this tap’s source-build style.
- Update English and Chinese README files to list `thrift@0.22` as the latest supported version.

- 新增从 `homebrew/core` 历史版本提取的 `thrift@0.22` formula。
- 按当前 tap 的源码构建风格整理新 formula。
- 更新英文和中文 README，将 `thrift@0.22` 标记为当前最新支持版本。

## Validation / 验证

- `brew audit --strict --online --formula cartman-kai/thrift/thrift@0.22`
- `brew style Formula/thrift@0.22.rb`
- `brew install --build-from-source cartman-kai/thrift/thrift@0.22`
- `brew test cartman-kai/thrift/thrift@0.22`

All validation commands completed successfully with no output.

以上验证命令均已成功执行，且没有输出错误信息。

## Notes / 说明

- Full tap audit may still report pre-existing issues in older formulae, unrelated to this change.
- This PR only adds `thrift@0.22` and updates documentation.

- 完整 tap 审计可能仍会报告旧版本 formula 中已有的问题，这些问题与本次变更无关。
- 本 PR 仅新增 `thrift@0.22` 并同步更新文档。
